### PR TITLE
Add Travis configurations to test for successful CMake builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,82 @@
+language: cpp
+os: linux
+compiler: gcc
+
+matrix:
+  include:
+    - name: CUDA 10
+      env:
+      - CUDA=10.1.105-1
+      - CUDA_SHORT=10.1
+      - UBUNTU_VERSION=ubuntu1804
+      dist: bionic
+
+before_install:
+  # C++14
+  - sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test
+  - sudo apt-get update -qq
+
+  # Install cuda
+  - wget http://developer.download.nvidia.com/compute/cuda/repos/${UBUNTU_VERSION}/x86_64/cuda-repo-${UBUNTU_VERSION}_${CUDA}_amd64.deb
+  - sudo apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub
+  - sudo dpkg -i cuda-repo-${UBUNTU_VERSION}_${CUDA}_amd64.deb
+  - sudo apt-get update -qq
+  - sudo apt-get install -y -qq --no-install-recommends --allow-unauthenticated cuda-10.1
+  - sudo apt clean
+  - CUDA_HOME=/usr/local/cuda-${CUDA_SHORT}
+  - LD_LIBRARY_PATH=${CUDA_HOME}/lib64:${LD_LIBRARY_PATH}
+  - PATH=${CUDA_HOME}/bin:${PATH}
+
+  # Install some version of OpenCL (prob wouldn't work in runtime)
+  - sudo apt install ocl-icd-opencl-dev
+
+# the install step will take care of deploying a newer cmake version
+install:  
+  # Qt5
+  - sudo apt-get install qt5-default libqt5opengl5-dev
+  # - sudo apt-get install mesa-common-dev
+  # - export QMAKE=/usr/lib/x86_64-linux-gnu/qt5/bin/qmake
+  - qmake --version
+
+  # LATEX - takes too long so just not gonna build tutorial
+  # - sudo apt install texlive-full
+
+  # OpenMPI
+  - sudo apt-get install openmpi-bin openmpi-common openssh-client openssh-server libopenmpi-dev
+
+  # FFTW3 used by Clicker
+  - sudo apt-get install libfftw3-dev libfftw3-doc
+
+  # first we create a directory for the CMake binaries
+  - DEPS_DIR="${TRAVIS_BUILD_DIR}/deps"
+  - mkdir ${DEPS_DIR} && cd ${DEPS_DIR}
+  # we use wget to fetch the cmake binaries
+  - travis_retry wget --no-check-certificate https://github.com/Kitware/CMake/releases/download/v3.15.5/cmake-3.15.5-Linux-x86_64.tar.gz
+  # extract the binaries; the output here is quite lengthy,
+  # so we swallow it to not clutter up the travis console
+  - tar -xvf cmake-3.15.5-Linux-x86_64.tar.gz > /dev/null
+  - mv cmake-3.15.5-Linux-x86_64 cmake-install
+  # add both the top-level directory and the bin directory from the archive
+  # to the system PATH. By adding it to the front of the path we hide the
+  # preinstalled CMake with our own.
+  - PATH=${DEPS_DIR}/cmake-install:${DEPS_DIR}/cmake-install/bin:$PATH
+  # don't forget to switch back to the main build directory once you are done
+  - cd ${TRAVIS_BUILD_DIR}
+
+before_script:
+  # create a build folder for the out-of-source build
+  - mkdir build
+  # switch to build directory
+  - cd build
+  # run cmake; here we assume that the project's
+  - gcc --version
+  # top-level CMakeLists.txt is located at '..'
+  - cmake ..
+
+script:
+  # Try making all tools with CMake targets
+  - make EmSART
+  - make Clicker
+  - make EmSARTRefine
+  - make ImageStackAlignator
+  - make EmSARTSubVols


### PR DESCRIPTION
Ignores building the tutorial to avoid wasting time installing texlive on Travis instance.
Still takes quite a bit to run since it has to install all the dependencies before making each tool.
Test run took 10 min 44 s.

@uermel I've tested this on my fork of the repository so it should be working fine to merge in. Just need you to go to Travis CI and give it access to your public repositories before you do it so that the test will start running automatically upon the merge.